### PR TITLE
FIxed a coumple of things requested by some users

### DIFF
--- a/doc/docker_build.md
+++ b/doc/docker_build.md
@@ -139,9 +139,10 @@ Once you've completed the steps above, follow the procedure below:
 
   The following images will be built:
 
-  - `crowler/crowler-engine`: The base image for the CROWler docker images.
-  - `crowler/crowler-api`: The CROWler API image.
-  - `crowler/crowler-vdi`: The CROWler Virtual Desktop Image.
+  - `crowler-engine-x`: The base image for the CROWler docker images.
+  - `crowler-api`: The CROWler API image.
+  - `crowler-vdi-x`: The CROWler Virtual Desktop Image.
+  - `crowler-events`: The CROWler Events Manager image.
 
   Plus a set of "support" images, that are used to build the main images.
 

--- a/doc/docker_build.md
+++ b/doc/docker_build.md
@@ -28,6 +28,8 @@ and configuring the build appropriately.
 
   **Note**: The above are the minimal requirements, you can run the CROWler on
   a machine with less resources, but you might experience performance issues.
+  Also, please note that the CROWler can collect an impressive amount of data,
+  so you might want to have more disk space available.
 
 - **Step B** There are a bunch of ENV variables you can set to
   customize the CROWler deployment. These ENV vars allow you to set up your

--- a/doc/docker_build.md
+++ b/doc/docker_build.md
@@ -24,7 +24,7 @@ and configuring the build appropriately.
   As for the minimal requirements for the machine you are building the CROWler:
   - 4GB of RAM
   - 2 CPU cores
-  - 20GB of disk space
+  - 30GB of disk space
 
   **Note**: The above are the minimal requirements, you can run the CROWler on
   a machine with less resources, but you might experience performance issues.

--- a/go.mod
+++ b/go.mod
@@ -32,7 +32,7 @@ require (
 	github.com/antchfx/xpath v1.3.3 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
-	github.com/chromedp/cdproto v0.0.0-20241222144035-c16d098c0fb6 // indirect
+	github.com/chromedp/cdproto v0.0.0-20250101192427-60a0ca35cb84 // indirect
 	github.com/chromedp/sysutil v1.1.0 // indirect
 	github.com/gobwas/httphead v0.1.0 // indirect
 	github.com/gobwas/pool v0.2.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -33,6 +33,8 @@ github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UF
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/chromedp/cdproto v0.0.0-20241222144035-c16d098c0fb6 h1:dAUcp/W5RpJSZW/HksEHfAAoMBIvSFFIwslAFEte+6g=
 github.com/chromedp/cdproto v0.0.0-20241222144035-c16d098c0fb6/go.mod h1:4XqMl3iIW08jtieURWL6Tt5924w21pxirC6th662XUM=
+github.com/chromedp/cdproto v0.0.0-20250101192427-60a0ca35cb84 h1:NXWP4iSVz4BPGk7Z/fPXL0c44hiWbrbyhBY0LwKKZnY=
+github.com/chromedp/cdproto v0.0.0-20250101192427-60a0ca35cb84/go.mod h1:4XqMl3iIW08jtieURWL6Tt5924w21pxirC6th662XUM=
 github.com/chromedp/chromedp v0.11.2 h1:ZRHTh7DjbNTlfIv3NFTbB7eVeu5XCNkgrpcGSpn2oX0=
 github.com/chromedp/chromedp v0.11.2/go.mod h1:lr8dFRLKsdTTWb75C/Ttol2vnBKOSnt0BW8R9Xaupi8=
 github.com/chromedp/sysutil v1.1.0 h1:PUFNv5EcprjqXZD9nJb9b/c9ibAbxiYo4exNWZyipwM=

--- a/pkg/plugin/plugins.go
+++ b/pkg/plugin/plugins.go
@@ -567,6 +567,7 @@ func addJSHTTPRequest(vm *otto.Otto) error {
 	{ "Authorization header": "Bearer token"},
 	{"key": "value"},
 	30000);
+
    console.log(response.status);
    console.log(response.headers);
    console.log(response.body);

--- a/services/events/helpers.go
+++ b/services/events/helpers.go
@@ -4,18 +4,23 @@ package main
 import (
 	"encoding/json"
 	"net/http"
+	"strings"
 
 	cmn "github.com/pzaino/thecrowler/pkg/common"
 )
 
 // handleErrorAndRespond encapsulates common error handling and JSON response logic.
 func handleErrorAndRespond(w http.ResponseWriter, err error, results interface{}, errMsg string, errCode int, successCode int) {
+	w.Header().Set("Content-Type", "application/json")
 	if err != nil {
 		cmn.DebugMsg(cmn.DbgLvlDebug3, errMsg, err)
-		http.Error(w, err.Error(), errCode)
+		// escape " in the error message
+		errMsg = strings.ReplaceAll(err.Error(), "\"", "\\\"")
+		// Encapsulate the error message in a JSON string
+		results := "{\n  \"error\": \"" + errMsg + "\"\n}"
+		http.Error(w, results, errCode)
 		return
 	}
-	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(successCode) // Explicitly set the success status code
 	if err := json.NewEncoder(w).Encode(results); err != nil {
 		// Log the error and send a generic error message to the client


### PR DESCRIPTION
This PR contains some substatial change:

1) After some user's requests I have disabled automatic re-crawling, now to have scheduled crawling a user must specify it in their config.yaml explicitely
2) the events API now uses the path `v1/event/<method>` as it should to be congruent with the rest of the API as we use always the subject in singular form (for some resons before event was events). Events is relatively new, so I don't believe there is anyone yet using it in their production environments
